### PR TITLE
Implemented interface for adding netcdf groups.

### DIFF
--- a/obs2ioda-v2/src/cxx/CMakeLists.txt
+++ b/obs2ioda-v2/src/cxx/CMakeLists.txt
@@ -1,6 +1,10 @@
 set(obs2ioda_cxx_SOURCES
     netcdf_error.cc
         netcdf_file.cc
+        netcdf_group.cc
+        netcdf_group.h
+        netcdf_utils.cc
+        netcdf_utils.h
 )
 set(obs2ioda_cxx_LIBRARIES
     NetCDF::NetCDF_CXX

--- a/obs2ioda-v2/src/cxx/netcdf_file.h
+++ b/obs2ioda-v2/src/cxx/netcdf_file.h
@@ -2,7 +2,6 @@
 #define OBS2IODA_NETCDF_FILE_H
 
 #include <netcdf>
-#include <map>
 #include <unordered_map>
 #include <memory>
 #include <mutex>

--- a/obs2ioda-v2/src/cxx/netcdf_group.cc
+++ b/obs2ioda-v2/src/cxx/netcdf_group.cc
@@ -1,0 +1,27 @@
+#include "netcdf_group.h"
+#include "netcdf_utils.h"
+#include "netcdf_file.h"
+#include <mutex>
+
+namespace Obs2Ioda {
+
+    int netcdfAddGroup(
+            int netcdfID,
+            const char *parentGroupName,
+            const char *groupName
+    ) {
+        try {
+            std::lock_guard<std::mutex> lock(map_mutex);
+            auto file = NETCDF_FILE_MAP[netcdfID];
+            auto group = getRootGroup(netcdfID, parentGroupName);
+            group->addGroup(groupName);
+            return 0;
+        } catch (netCDF::exceptions::NcException &e) {
+            return netcdfErrorMessage(
+                    e,
+                    1
+            );
+        }
+    }
+
+}

--- a/obs2ioda-v2/src/cxx/netcdf_group.h
+++ b/obs2ioda-v2/src/cxx/netcdf_group.h
@@ -1,0 +1,17 @@
+#ifndef NETCDF_GROUP_H
+#define NETCDF_GROUP_H
+
+namespace Obs2Ioda {
+
+    extern "C" {
+        int netcdfAddGroup(
+                int netcdfID,
+                const char *parentGroupName,
+                const char *groupName
+        );
+
+    }
+
+}
+
+#endif //NETCDF_GROUP_H

--- a/obs2ioda-v2/src/cxx/netcdf_utils.cc
+++ b/obs2ioda-v2/src/cxx/netcdf_utils.cc
@@ -1,0 +1,63 @@
+#include "netcdf_utils.h"
+#include "netcdf_file.h"
+#include <algorithm>
+#include <iostream>
+
+namespace Obs2Ioda {
+
+    std::shared_ptr<netCDF::NcGroup> getRootGroup(
+            int netcdfID,
+            const char *groupName
+    ) {
+        auto file = NETCDF_FILE_MAP[netcdfID];
+        if (groupName != nullptr) {
+            return std::make_shared<netCDF::NcGroup>(file->getGroup(groupName));
+        }
+        return file;
+    }
+
+    std::string removeWhiteSpace(
+            const std::string &name
+    ) {
+        std::string strippedName = name;
+
+        strippedName.erase(
+                std::remove_if(
+                        strippedName.begin(),
+                        strippedName.end(),
+                        [](unsigned char x) { return std::isspace(x); }
+                ),
+                strippedName.end()
+        );
+        return strippedName;
+    }
+
+
+    std::string getIodaName(
+            const char *name,
+            const std::unordered_map<
+                    std::string,
+                    std::string
+            > &iodaNameMap
+    ) {
+        // Remove white spaces from the name
+        std::string iodaName = removeWhiteSpace(name);
+
+        // Check if the name exists in the map
+        if (iodaNameMap.find(iodaName) != iodaNameMap.end()) {
+            return iodaNameMap.at(iodaName);
+        }
+        return iodaName;
+    }
+
+    int netcdfErrorMessage(
+            netCDF::exceptions::NcException &e,
+            int errorCode
+    ) {
+        std::cerr
+                << "NetCDF Error: "
+                << e.what()
+                << std::endl;
+        return errorCode;
+    }
+}

--- a/obs2ioda-v2/src/cxx/netcdf_utils.h
+++ b/obs2ioda-v2/src/cxx/netcdf_utils.h
@@ -1,0 +1,34 @@
+#ifndef NETCDF_UTILS_H
+#define NETCDF_UTILS_H
+
+#include <netcdf>
+#include <unordered_map>
+#include <memory>
+
+namespace Obs2Ioda {
+
+    std::string getIodaName(
+            const char *name,
+            const std::unordered_map<
+                    std::string,
+                    std::string
+            > &iodaNameMap
+    );
+
+    int netcdfErrorMessage(
+            netCDF::exceptions::NcException &e,
+            int errorCode
+    );
+
+    std::shared_ptr<netCDF::NcGroup> getRootGroup(
+            int netcdfID,
+            const char *groupName
+    );
+
+    std::string removeWhiteSpace(
+            const std::string &name
+    );
+
+}
+
+#endif //NETCDF_UTILS_H

--- a/obs2ioda-v2/src/netcdf_cxx_i_mod.f90
+++ b/obs2ioda-v2/src/netcdf_cxx_i_mod.f90
@@ -19,6 +19,18 @@ module netcdf_cxx_i_mod
             integer(c_int), value, intent(in) :: netcdfID
             integer(c_int) :: c_netcdfClose
         end function
+
+        function c_netcdfAddGroup(&
+                netcdfID, parentGroupName, groupName) &
+                bind(C, name = "netcdfAddGroup")
+            import :: c_int
+            import :: c_ptr
+            integer(c_int), value, intent(in) :: netcdfID
+            type(c_ptr), value, intent(in) :: parentGroupName
+            type(c_ptr), value, intent(in) :: groupName
+            integer(c_int) :: c_netcdfAddGroup
+        end function c_netcdfAddGroup
+
     end interface
 
 end module netcdf_cxx_i_mod

--- a/obs2ioda-v2/src/netcdf_cxx_mod.f90
+++ b/obs2ioda-v2/src/netcdf_cxx_mod.f90
@@ -1,5 +1,5 @@
 module netcdf_cxx_mod
-    use iso_c_binding, only : c_char, c_null_char, c_null_ptr, c_int
+    use iso_c_binding, only : c_char, c_null_char, c_null_ptr, c_int, c_ptr
     use f_c_string_t_mod, only : f_c_string_t
     use f_c_string_1D_t_mod, only : f_c_string_1D_t
     use netcdf_cxx_i_mod
@@ -25,6 +25,27 @@ contains
         integer(c_int) :: netcdfClose
         netcdfClose = c_netcdfClose(netcdfID)
     end function netcdfClose
+
+    function netcdfAddGroup(netcdfID, groupName, parentGroupName)
+        integer(c_int), value, intent(in) :: netcdfID
+        character(len = *), intent(in), optional :: parentGroupName
+        character(len = *), intent(in) :: groupName
+        integer(c_int) :: netcdfAddGroup
+        type(c_ptr) :: c_parentGroupName
+        type(c_ptr) :: c_groupName
+        type(f_c_string_t) :: f_c_string_parentGroupName
+        type(f_c_string_t) :: f_c_string_groupName
+
+        if (present(parentGroupName)) then
+            c_parentGroupName = f_c_string_parentGroupName%to_c(parentGroupName)
+        else
+            c_parentGroupName = c_null_ptr
+        end if
+        c_groupName = f_c_string_groupName%to_c(groupName)
+
+        netcdfAddGroup = c_netcdfAddGroup(netcdfID, c_parentGroupName, c_groupName)
+    end function netcdfAddGroup
+
 
 
 end module netcdf_cxx_mod

--- a/test/cxx/netcdf_test.cc
+++ b/test/cxx/netcdf_test.cc
@@ -1,5 +1,6 @@
 #include "netcdf_test_fixture.h"
 #include "netcdf_file.h"
+#include "netcdf_group.h"
 #include <gtest/gtest.h>
 
 // Example test case using the fixture
@@ -8,6 +9,29 @@ TEST_F(NetCDFTestFixture, NetCDFCreateTest) {
     int status = Obs2Ioda::netcdfCreate(
             this->test_file_path.c_str(),
             &netcdfID
+    );
+    EXPECT_EQ(status, 0);
+    status = Obs2Ioda::netcdfClose(netcdfID);
+    EXPECT_EQ(status, 0);
+}
+
+TEST_F(NetCDFTestFixture, NetCDFAddGroupTest) {
+    int netcdfID{};
+    int status = Obs2Ioda::netcdfCreate(
+            this->test_group_path.c_str(),
+            &netcdfID
+    );
+    EXPECT_EQ(status, 0);
+    status = Obs2Ioda::netcdfAddGroup(
+            netcdfID,
+            nullptr,
+            this->test_group_name.c_str()
+    );
+    EXPECT_EQ(status, 0);
+    status = Obs2Ioda::netcdfAddGroup(
+            netcdfID,
+            this->test_group_name.c_str(),
+            this->test_nested_group_name.c_str()
     );
     EXPECT_EQ(status, 0);
     status = Obs2Ioda::netcdfClose(netcdfID);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for creating and managing NetCDF file groups
	- Introduced new functions for NetCDF group manipulation in C++ and Fortran interfaces

- **Tests**
	- Added test case for NetCDF group creation and nesting functionality

- **Refactor**
	- Removed `<map>` include and updated related utility functions
	- Added new utility methods for NetCDF file and group handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->